### PR TITLE
fix: fallback to native key not work

### DIFF
--- a/autoload/navigator.vim
+++ b/autoload/navigator.vim
@@ -172,7 +172,12 @@ function! navigator#start(visual, bang, args, line1, line2, count) abort
 		let keys = s:key_translate([prefix] + path)
 		let keys = navigator#charname#mapname(keys)
 		exec visual
-		call feedkeys(keys)
+		let l:map = mapcheck(keys, a:visual ? 'v' : 'n')
+		if l:map ==# '' || l:map =~ 'Navigator'
+			call feedkeys(keys, 'n')
+		else
+			exec printf('%s%s', range, l:map)
+		endif
 	endif
 endfunc
 
@@ -182,7 +187,7 @@ endfunc
 "----------------------------------------------------------------------
 function! s:key_translate(array) abort
 	let output = []
-	for cc in array
+	for cc in a:array
 		let ch = navigator#charname#get_key_code(cc)
 		if ch == ''
 			let ch = cc

--- a/autoload/navigator/state.vim
+++ b/autoload/navigator/state.vim
@@ -197,6 +197,8 @@ function! navigator#state#select(keymap, path) abort
 			if s:exit != 0
 				return []
 			endif
+		else
+			return path + [ch]
 		endif
 	endwhile
 endfunc


### PR DESCRIPTION
When I config as this:

```vim
let g:key_g = {
            \   'prefix': 'g',
            \   'name': 'g',
            \   'g': ['<KEY>gg',  'Goto first line'],
            \ }
nnormap <silent> g :<C-U>Navigator g:key_g<CR>
nnormap gA :echo 123<CR>
```

After Navigator window show, I can't enter characters other than the 'g' character.

And this change is to return the key I enter in the 'g' Navigator show windows,
add the prefix key, and call feedkey or execute a map.