### PR TITLE
add-feature: support Funcref as cmd

### DIFF
--- a/autoload/navigator.vim
+++ b/autoload/navigator.vim
@@ -140,8 +140,11 @@ function! navigator#start(visual, bang, args, line1, line2, count) abort
 		let range = printf("%d", a:count)
 	endif
 	if type(hr) == v:t_list
-		let cmd = (len(hr) > 0)? hr[0] : ''
 		try
+			if type(hr[0]) == v:t_func
+				return call(hr[0], [])
+			endif
+			let cmd = (len(hr) > 0)? hr[0] : ''
 			if cmd =~ '^[a-zA-Z0-9_#]\+(.*)$'
 				exec printf('%scall %s', range, cmd)
 			elseif cmd =~# '^<key>'


### PR DESCRIPTION
Add feature to support Funcref as cmd.

After this, I can config:

```vim
function! s:test() abort
    echom "test"
endfunction

let g:key_g = {
            \   'prefix': 'g',
            \   'name': 'g',
            \   'g': ['<KEY>gg',  'Goto first line'],
            \   't': [function('s:test'),  'test function'],
            \ }
nnormap <silent> g :<C-U>Navigator g:key_g<CR>
```

And this is easy to execute commands in script-function.

Another question is whether it is possiblie to support function parameters.

If support, can change to like this:

```vim
return call(hr[0], hr[2:])
```