### PR TITLE
feature: add silent to call win close, than no show '--No lines in buffer--'

### DIFF
--- a/autoload/navigator/display.vim
+++ b/autoload/navigator/display.vim
@@ -405,9 +405,9 @@ endfunc
 "----------------------------------------------------------------------
 function! navigator#display#close() abort
 	if s:popup == 0
-		call s:win_close()
+		silent call s:win_close()
 	else
-		call s:popup_close()
+		silent call s:popup_close()
 	endif
 endfunc
 


### PR DESCRIPTION
If buffer has some word, and delte all like:

```vim
:1,$d
```

It will show '--No lines in buffer--'

So add `silent call`, can no show this.