### PR TITLE
fix: fallback return key error; functref support visual; redraw after close

### DIFF
--- a/autoload/navigator.vim
+++ b/autoload/navigator.vim
@@ -143,6 +143,7 @@ function! navigator#start(visual, bang, args, line1, line2, count) abort
 	if type(hr) == v:t_list
 		try
 			if type(hr[0]) == v:t_func
+				exec visual
 				return call(hr[0], [])
 			endif
 			let cmd = (len(hr) > 0)? hr[0] : ''

--- a/autoload/navigator/state.vim
+++ b/autoload/navigator/state.vim
@@ -199,7 +199,7 @@ function! navigator#state#select(keymap, path) abort
 				return []
 			endif
 		elseif fallback
-			return path + [ch]
+			return [ch]
 		endif
 	endwhile
 endfunc
@@ -224,6 +224,7 @@ function! navigator#state#open(keymap, opts) abort
 		silent call navigator#display#show_cursor()
 	endif
 	call navigator#state#close()
+	redraw
 	return key_array
 endfunc
 


### PR DESCRIPTION
I made some mistakes in previous commits:
1. fallback return key just return the current char, and will add the previous char with `has_key` branch
2. funcref also need visual before call
3. If it need redraw after close popup window？ in my test, sometimes will leave a window when execute command.