### PR TITLE
feature: show window only after timeout

### DIFF
--- a/autoload/navigator.vim
+++ b/autoload/navigator.vim
@@ -32,6 +32,7 @@ let s:config_name = {
 			\ 'popup_border': 1,
 			\ 'hide_cursor': 0,
 			\ 'fallback': 0,
+			\ 'timeout': 0,
 			\ }
 
 


### PR DESCRIPTION
add option "timeout":
1. before timeout, no show window and execute input key
2. after timeout, show window, handle input, execute it

If I remember the shortcut key, the display window is not necessary.
This can make the program run faster!!!

In my pc, show window need 1s+...