### PR TITLE
fix: use a:path not l:path to fix 'BADKEY' show

### DIFF
--- a/autoload/navigator/state.vim
+++ b/autoload/navigator/state.vim
@@ -295,7 +295,7 @@ function! navigator#state#select_silent(keymap, path) abort
 
 	" open and init window opts first
 	call navigator#state#open_window()
-	let key_array = navigator#state#select_window(a:keymap, path)
+	let key_array = navigator#state#select_window(a:keymap, a:path)
 	call navigator#state#close_window()
 
 	return key_array


### PR DESCRIPTION

![image](https://github.com/skywind3000/vim-navigator/assets/7224981/48e4edf1-dc39-4605-a234-0bd45993b99d)

[`navigator#state#select_silent() => s:translate_path()`](https://github.com/skywind3000/vim-navigator/blob/master/autoload/navigator/state.vim#L244)
return with `s:prefix`, so when call `navigator#state#select_window()`, `path` is dirty!